### PR TITLE
Switch auth service to JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ GTM Strategy application built with Spring Boot.
 
 The project includes a PostgreSQL schema located at `src/main/resources/schema.sql`.
 Execute this script using a PostgreSQL client to create the necessary tables.
+
+## Authentication
+
+APIs require a valid JWT for access. Configure the secret key via the
+`jwt.secret` property in `application.properties` or as an environment
+variable.

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,29 @@
             <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/kaustav/launchit/controller/AuthController.java
+++ b/src/main/java/com/kaustav/launchit/controller/AuthController.java
@@ -1,0 +1,41 @@
+package com.kaustav.launchit.controller;
+
+import com.kaustav.launchit.service.AuthService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Controller for authentication operations.
+ */
+@RestController
+@RequestMapping("/api")
+public class AuthController {
+    private static final Logger log = LoggerFactory.getLogger(AuthController.class);
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    /**
+     * Login endpoint that returns a JWT token on success.
+     */
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
+        log.info("POST /api/login for {}", request.username);
+        String token = authService.login(request.username, request.password);
+        if (token == null) {
+            return ResponseEntity.status(401).build();
+        }
+        return ResponseEntity.ok(new TokenResponse(token));
+    }
+
+    /** Request body for login. */
+    public record LoginRequest(String username, String password) {}
+
+    /** Simple token response body. */
+    public record TokenResponse(String token) {}
+}

--- a/src/main/java/com/kaustav/launchit/controller/AuthTokenFilter.java
+++ b/src/main/java/com/kaustav/launchit/controller/AuthTokenFilter.java
@@ -1,0 +1,50 @@
+package com.kaustav.launchit.controller;
+
+import com.kaustav.launchit.service.AuthService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Filter that validates JWT tokens on each API request.
+ */
+@Component
+public class AuthTokenFilter extends OncePerRequestFilter {
+    private static final Logger log = LoggerFactory.getLogger(AuthTokenFilter.class);
+    private final AuthService authService;
+
+    public AuthTokenFilter(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+        log.debug("Filtering {} {}", request.getMethod(), path);
+        // Allow login endpoint without token
+        if ("/api/login".equals(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String header = request.getHeader("Authorization");
+        String token = (header != null && header.startsWith("Bearer "))
+                ? header.substring(7) : null;
+        if (token != null && authService.validate(token)) {
+            log.debug("Authorized request for {}", path);
+            filterChain.doFilter(request, response);
+        } else {
+            log.warn("Unauthorized request for {}", path);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/kaustav/launchit/db/User.java
+++ b/src/main/java/com/kaustav/launchit/db/User.java
@@ -1,0 +1,23 @@
+package com.kaustav.launchit.db;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/kaustav/launchit/db/UserRepository.java
+++ b/src/main/java/com/kaustav/launchit/db/UserRepository.java
@@ -1,0 +1,9 @@
+package com.kaustav.launchit.db;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/kaustav/launchit/service/AuthService.java
+++ b/src/main/java/com/kaustav/launchit/service/AuthService.java
@@ -1,0 +1,65 @@
+package com.kaustav.launchit.service;
+
+import com.kaustav.launchit.db.User;
+import com.kaustav.launchit.db.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.JwtException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Service providing basic JWT-based authentication.
+ */
+@Service
+public class AuthService {
+    private static final Logger log = LoggerFactory.getLogger(AuthService.class);
+
+    private final byte[] secret;
+
+    private final UserRepository userRepository;
+
+    public AuthService(UserRepository userRepository,
+                       @Value("${jwt.secret:changeit-secret-key}") String secret) {
+        this.userRepository = userRepository;
+        this.secret = secret.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Authenticate a username/password pair. Returns a token if valid.
+     */
+    public String login(String username, String password) {
+        return userRepository.findByUsername(username)
+                .filter(u -> u.getPassword().equals(password))
+                .map(u -> {
+                    String token = Jwts.builder()
+                            .setSubject(Integer.toString(u.getId()))
+                            .signWith(Keys.hmacShaKeyFor(secret), SignatureAlgorithm.HS256)
+                            .compact();
+                    log.info("Generated JWT for user {}", username);
+                    return token;
+                })
+                .orElse(null);
+    }
+
+    /**
+     * Validate a token.
+     */
+    public boolean validate(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(secret))
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException e) {
+            log.warn("Invalid JWT: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,4 +2,5 @@ spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=none
+jwt.secret=changeit-secret-key
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -110,3 +110,11 @@ CREATE TABLE credits (
     settled BOOLEAN DEFAULT FALSE,
     party_type VARCHAR CHECK (party_type IN ('brand', 'retailer'))
 );
+
+-- Users for authentication
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR NOT NULL UNIQUE,
+    password VARCHAR NOT NULL,
+    created_at TIMESTAMP DEFAULT now()
+);

--- a/src/test/java/com/kaustav/launchit/AuthServiceTest.java
+++ b/src/test/java/com/kaustav/launchit/AuthServiceTest.java
@@ -1,0 +1,29 @@
+package com.kaustav.launchit;
+
+import com.kaustav.launchit.db.User;
+import com.kaustav.launchit.db.UserRepository;
+import com.kaustav.launchit.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AuthServiceTest {
+    @Test
+    void loginReturnsTokenForValidCredentials() {
+        UserRepository repo = Mockito.mock(UserRepository.class);
+        User user = new User();
+        user.setId(1);
+        user.setUsername("john");
+        user.setPassword("pass");
+        Mockito.when(repo.findByUsername("john")).thenReturn(Optional.of(user));
+
+        AuthService service = new AuthService(repo, "test-secret");
+        String token = service.login("john", "pass");
+        assertNotNull(token);
+        assertTrue(token.split("\\.").length >= 2); // basic JWT structure
+        assertTrue(service.validate(token));
+    }
+}


### PR DESCRIPTION
## Summary
- migrate token generation to JWT
- update the request filter to expect `Bearer` tokens and add debug logging
- read JWT secret from `jwt.secret` property
- document JWT setup in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685ef8500e088320ba5509f68a6b5189