### PR TITLE
Fix JWT parser call

### DIFF
--- a/src/main/java/com/kaustav/launchit/service/AuthService.java
+++ b/src/main/java/com/kaustav/launchit/service/AuthService.java
@@ -52,8 +52,8 @@ public class AuthService {
      */
     public boolean validate(String token) {
         try {
-            Jwts.parserBuilder()
-                    .setSigningKey(Keys.hmacShaKeyFor(secret))
+            Jwts.parser()
+                    .verifyWith(Keys.hmacShaKeyFor(secret))
                     .build()
                     .parseClaimsJws(token);
             return true;


### PR DESCRIPTION
## Summary
- update AuthService to use `Jwts.parser()` API introduced in jjwt 0.12.x

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686a338219408320b8bf36b40f0bcd47